### PR TITLE
add 'for:' field to cadvisor prometheus rule

### DIFF
--- a/charts/perfectscale-agent/templates/prometheus-rule.yaml
+++ b/charts/perfectscale-agent/templates/prometheus-rule.yaml
@@ -56,6 +56,9 @@ spec:
             summary: "{{ $fullName }} high cAdvisor scraping error rate"
           expr: |
             (increase(psc_exporter_cadvisor_scraping_errors_total[{{ .Values.prometheusRule.cAdvisorScraping.timeRange }}]) / avg_over_time(psc_exporter_cadvisor_instances_scraped[{{ .Values.prometheusRule.cAdvisorScraping.timeRange }}])) > {{ .Values.prometheusRule.cAdvisorScraping.threshold }}
+          {{- if .Values.prometheusRule.cAdvisorScraping.for }}
+          for: {{ .Values.prometheusRule.cAdvisorScraping.for }}
+          {{- end }}
           labels:
             {{- if .Values.prometheusRule.team }}
             team: {{ .Values.prometheusRule.team }}

--- a/charts/perfectscale-agent/values.yaml
+++ b/charts/perfectscale-agent/values.yaml
@@ -164,6 +164,7 @@ prometheusRule:
   cAdvisorScraping:
     timeRange: "30m"
     threshold: 0.3
+    for: "30m"
   cpuUtilization:
     enable: false
     threshold: 8 # default value


### PR DESCRIPTION
allows the 'for' field to be configurable through values.yaml. this is useful if cadvisor metrics may be unavailable for a known amount of time, depending on environment.