### PR TITLE
feat: Allowed coroot container's environment variables to be customized from helm values

### DIFF
--- a/charts/perfectscale-agent/templates/coroot.yaml
+++ b/charts/perfectscale-agent/templates/coroot.yaml
@@ -38,22 +38,10 @@ spec:
           image: "{{ .Values.coroot.image.repository }}:{{ .Values.coroot.image.tag }}"
           imagePullPolicy: {{ .Values.coroot.image.pullPolicy }}
           env:
-            - name: CGROUPFS_ROOT
-              value: "/host/sys/fs/cgroup"
-            - name: DISABLE_LOG_PARSING
-              value: "true"
-            - name: COROOT_EBPF_PROFILING
-              value: "disabled"
-            - name: COROOT_LOG_MONITORING
-              value: "disabled"
-            - name: COROOT_EBPF_TRACES
-              value: "disabled"
-            - name: DISABLE_L7_TRACING
-              value: "true"
-            - name: LISTEN
-              value: "0.0.0.0:8080"
-            - name: GLOG_v
-              value: "4"
+            {{- range $key, $val := .Values.coroot.env }}
+            - name: {{ $key | quote }}
+              value: {{ $val | quote }}
+            {{- end }}         
           ports:
             - containerPort: 8080
               name: http

--- a/charts/perfectscale-agent/values.yaml
+++ b/charts/perfectscale-agent/values.yaml
@@ -339,6 +339,16 @@ coroot:
     requests:
       cpu: 10m
       memory: 50Mi
+  ## environment variables of the coroot-node-agent container
+  env:
+    CGROUPFS_ROOT: "/host/sys/fs/cgroup"
+    DISABLE_LOG_PARSING: "true"
+    COROOT_EBPF_PROFILING: "disabled"
+    COROOT_LOG_MONITORING: "disabled"
+    COROOT_EBPF_TRACES: "disabled"
+    DISABLE_L7_TRACING: "true"
+    LISTEN: "0.0.0.0:8080"
+    GLOG_v: "4"
   ## Additional labels to set in the all objects. Together with standard labels from the chart
   additionalLabels: {}
   ## Labels to add to the pod


### PR DESCRIPTION
Closes https://github.com/perfectscale-io/perfectscale-io.github.io/issues/13

Note: 
1. This is not a breaking change (hard coded values are now templatized)
2. It looks odd, but the reason why I'm using a map for env vars instead of list, is because it's a helm best practice. (map values can be merged and overriden) (list values have edge case troubles with merge and override)
3. And helm v3 -> v4 has a breaking change involving this very edge case of map vs list, (https://github.com/helm/helm/issues/31529), this best practice method avoids the issue they're refering to.

Test methodlogy: 
1. get kubectl access to a test cluster
2. clone the repo to your local machine's home directory
3. change your git branch to this feature
4. run the following test command
```bash
tee ~/perfectscale-exporter.test-helm-values.yaml << EOF
settings:
  corootNodeAgent:
    enabled: true
coroot:
  env:
    ENABLE_JAVA_ASYNC_PROFILER: "false"
EOF

cat ~/perfectscale-exporter.test-helm-values.yaml 

helm get values perfectscale -n=perfectscale

helm upgrade --install perfectscale -n=perfectscale --create-namespace \
  --values=$HOME/perfectscale-exporter.test-helm-values.yaml \
  ~/perfectscale-io.github.io/charts/perfectscale-agent
```
