### PR TITLE
feat(exporter): render settings.clusterName through tpl

### DIFF
--- a/charts/perfectscale-agent/templates/cr-manager/deployment.yaml
+++ b/charts/perfectscale-agent/templates/cr-manager/deployment.yaml
@@ -93,7 +93,7 @@ spec:
           - name: CLUSTER_UID
             value: "{{ include "helm.exporter.clusterUID" . }}"
           - name: CLUSTER_NAME
-            value: "{{ .Values.settings.clusterName }}"
+            value: "{{ tpl .Values.settings.clusterName . }}"
           - name: CR_MANAGER_NAMESPACE
             value: "{{ .Release.Namespace }}"
           - name: "KUBERNETES_CLIENT_BURST"

--- a/charts/perfectscale-agent/templates/deployment.yaml
+++ b/charts/perfectscale-agent/templates/deployment.yaml
@@ -176,7 +176,7 @@ spec:
           - name: "KSM_IMAGE_NAME"
             value: "{{ .Values.settings.scraper.ksmImageName }}"
           - name: "CLUSTER_NAME"
-            value: "{{ .Values.settings.clusterName }}"
+            value: "{{ tpl .Values.settings.clusterName . }}"
           - name: REMOTE_LOG_BATCH_SIZE
             value: "{{ include "helm.exporter.remoteLogBatchSize" . }}"
           - name: REMOTE_LOG_BATCH_INTERVAL


### PR DESCRIPTION
this change renders `settings.clusterName` through `tpl` in the two deployments that set `CLUSTER_NAME`, so the value can reference other chart values, like `clusterName: '{{ .Values.global.cluster.name }}'`.

why? because when the exporter runs as a subchart in a fleet umbrella chart (like an Argo CD ApplicationSet + one Application per cluster), the cluster name can arrive through a templatized `global.*` value. As of today `settings.clusterName` can only accept a literal, so fleet consumers must maintain one values file per cluster just to add the name and pass this value (instead of it being templatized automatically by other means). 

With `tpl`, the umbrella chart could set it once and it would be resolved per cluster.

normally it's backwards compatible: `tpl` on a literal returns it the same it was.

```console
# literal: same output as before this change
helm template charts/perfectscale-agent \
  --set-string settings.clusterName=my-cluster | grep -A1 CLUSTER_NAME

# templatized: resolves through tpl (values file because --set-string can't parse braces)
cat > /tmp/tpl-values.yaml <<'EOF'
global:
  cluster:
    name: my-cluster
settings:
  clusterName: '{{ .Values.global.cluster.name }}'
EOF
helm template charts/perfectscale-agent -f /tmp/tpl-values.yaml | grep -A1 CLUSTER_NAME
```

both print `value: "my-cluster"` in `deployment.yaml` and `cr-manager/deployment.yaml`.

I'll leave up to maintainers to create an abstraction or propagate this among the different values after assesing the risk

thank you!
